### PR TITLE
Use the right URL in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This configuration can be installed with `conan config install`.
 ## Using
 
 ```bash
-$ conan config install git@octocat.dlogics.com:datalogics/conan-config.git
+$ conan config install git@github.com:datalogics/conan-config.git
 ```
 
 ## Tagging


### PR DESCRIPTION
It was pointing to our internal GitHub before