### PR TITLE
Include global for msvc and fix some unrecognized options for llvm

### DIFF
--- a/profiles/llvm-toolset-7.0
+++ b/profiles/llvm-toolset-7.0
@@ -6,11 +6,9 @@ os=Linux
 arch=x86_64
 compiler=clang
 compiler.version=7.0
-compiler.toolset=llvm-toolset-7
 compiler.libcxx=libstdc++
 compiler.runtime=dynamic
-compiler.runtime_type=None
-compiler.runtime_version=None
+compiler.runtime_type=Release
 build_type=Release
 [buildenv]
 CC=/opt/rh/llvm-toolset-7.0/root/usr/bin/clang

--- a/profiles/msvc-common
+++ b/profiles/msvc-common
@@ -1,3 +1,4 @@
+include(global)
 [options]
 # --hash makes shorter filenames in the build directory, to avoid problems
 # on Windows, where b2.exe is 32-bit and doesn't support long paths.


### PR DESCRIPTION
Include global for msvc
Remove unrecognized compiler.toolset for llvm
Set compiler.runtime_type to Release
Remove unrecognized compiler.runtime_version