### PR TITLE
Add missing fields to llvm-toolset-7.0

### DIFF
--- a/profiles/llvm-toolset-7.0
+++ b/profiles/llvm-toolset-7.0
@@ -6,9 +6,11 @@ os=Linux
 arch=x86_64
 compiler=clang
 compiler.version=7.0
+compiler.toolset=llvm-toolset-7
 compiler.libcxx=libstdc++
 compiler.runtime=dynamic
 compiler.runtime_type=Release
+compiler.runtime_version=v143
 build_type=Release
 [buildenv]
 CC=/opt/rh/llvm-toolset-7.0/root/usr/bin/clang


### PR DESCRIPTION
These fields were missing when I tried to build API Engine on Linux:

- `compiler.toolset`=`llvm-toolset-7`
- `compiler.runtime_version`=`v143`
