### PR TITLE
Bump apple-clang-15.0 profile to bild for MacOS 10.15.

### DIFF
--- a/profiles/apple-clang-15.0
+++ b/profiles/apple-clang-15.0
@@ -1,4 +1,4 @@
-include(macos-10.13)
+include(macos-10.15)
 include(options-libtiff)
 include(boost-options)
 [settings]

--- a/profiles/macos-10.15
+++ b/profiles/macos-10.15
@@ -1,0 +1,5 @@
+[settings]
+os=Macos
+os.version=10.15
+[buildenv]
+MACOSX_DEPLOYMENT_TARGET=10.15


### PR DESCRIPTION
Bump apple-clang-15.0 profile to bild for MacOS 10.15.