### PR TITLE
Use compiler.update=2 for MSVC 194

### DIFF
--- a/profiles/msvc-194
+++ b/profiles/msvc-194
@@ -1,4 +1,6 @@
 include(msvc-common)
 [settings]
 compiler.version=194
+compiler.update=2
+
 


### PR DESCRIPTION
We're seeing "14.49" for a selected toolset version, and that doesn't exist. Override the last digit in 14.4 configurations.