### PR TITLE
More updates to the AIX profile

### DIFF
--- a/profiles/gcc-10-aix-72
+++ b/profiles/gcc-10-aix-72
@@ -7,6 +7,7 @@ compiler=gcc
 compiler.version=10.3
 compiler.libcxx=libstdc++
 compiler.threads=None
+compiler.exception=None
 build_type=Release
 [options]
 # Fix up building b2 on AIX. This will skip toolset autodetection and make b2

--- a/profiles/gcc-10-aix-72
+++ b/profiles/gcc-10-aix-72
@@ -6,6 +6,7 @@ os.version=7.2
 compiler=gcc
 compiler.version=10.3
 compiler.libcxx=libstdc++
+compiler.threads=None
 build_type=Release
 [options]
 # Fix up building b2 on AIX. This will skip toolset autodetection and make b2

--- a/profiles/gcc-10-aix-72
+++ b/profiles/gcc-10-aix-72
@@ -8,6 +8,7 @@ compiler.version=10.3
 compiler.libcxx=libstdc++
 compiler.threads=None
 compiler.exception=None
+
 build_type=Release
 [options]
 # Fix up building b2 on AIX. This will skip toolset autodetection and make b2
@@ -18,6 +19,7 @@ build_type=Release
 # New b2 build script in 4.7.1 needs cxx toolset to work with use_cxx_env.
 b2/*:toolset=cxx
 b2/*:use_cxx_env=True
+giflib/*:utils=False
 [buildenv]
 CONAN_CPU_COUNT=4
 CC=/opt/freeware/bin/gcc-10

--- a/profiles/gcc-10-aix-72
+++ b/profiles/gcc-10-aix-72
@@ -6,7 +6,7 @@ os.version=7.2
 compiler=gcc
 compiler.version=10.3
 compiler.libcxx=libstdc++
-compiler.threads=None
+compiler.threads=posix
 compiler.exception=None
 
 build_type=Release


### PR DESCRIPTION
Adds:

* compiler.threads=None
* compiler.exception=None

* giflib/*:utils=False < -- Old setting from conan-config because the executable utilities do not build on AIX (we don't use them)