### PR TITLE
Correct opencv settings in Windows ARM profile

### DIFF
--- a/profiles/msvc-arm64
+++ b/profiles/msvc-arm64
@@ -11,5 +11,5 @@ libiconv/*:arch=x86_64
 opencv/*:neon=True
 [conf]
 tools.gnu:host_triplet=aarch64-w64-mingw32
-opencv:tools.cmake.cmaketoolchain:cxxflags+=-D_ARM64_DISTINCT_NEON_TYPES=1
-opencv:tools.build:defines+=["ENABLE_NEON=ON", "OPENCV_ENABLE_FP16=ON"]
+opencv/*:tools.build:cxxflags+=-D_ARM64_DISTINCT_NEON_TYPES=1
+opencv/*:tools.build:defines+=["ENABLE_NEON=ON", "OPENCV_ENABLE_FP16=ON"]


### PR DESCRIPTION
- The curated-conan-center-index CI is failing to build packages (doxygen, swig, etc.) because the syntax of the opencv settings in the [conf] section of the profile are not Conan 2 compatible. Let's fix those settings so Conan 2 can recognize them and the packages can build on Windows ARM.

The error that we're running into on curated-conan-center-index is:

> Creating package ninja/1.12.1: conan create recipes\ninja\all -v --name ninja --version 1.12.1 --update --format=json --out-file C:\Users\devauto\AppData\Local\Temp\pytest-of-devauto\pytest-809\test_prebuilding_packages_ninj0\create.json --profile:host msvc-arm64-193-cppstd-14 --profile:build msvc-arm64-193-cppstd-14 --build missing
ERROR: [conf] Either 'tools.cmake.cmaketoolchain:cxxflags' does not exist in configuration list or the conf format introduced is not valid. Run 'conan config list' to see all the available confs.