### PR TITLE
Add boost-options to Rocky 8 Linux profile

### DIFF
--- a/profiles/clang-18-linux
+++ b/profiles/clang-18-linux
@@ -1,3 +1,4 @@
+include(boost-options)
 [settings]
 os=Linux
 compiler=clang
@@ -8,4 +9,3 @@ build_type=Release
 [buildenv]
 CC=/usr/bin/clang
 CXX=/usr/bin/clang++
-


### PR DESCRIPTION
- When trying to update apdfl-cpp-utils to Conan 2, the apdfl-cpp-utils bootstrap was running into the following error:
` ERROR: conanfile.py (apdfl_cpp_utils/2.0.7-dev.1): Invalid ID: Invalid: Boost must be set up to use ICU as an i18n backend`

- The ICU i18n backend option is already set to True in the boost-options profile, so let's include it in the clang-18-linux profile to get past this issue.

**Relates to Jira issue** [APDFL-6053](https://datalogics-jira.atlassian.net/browse/APDFL-6053)

[APDFL-6053]: https://datalogics-jira.atlassian.net/browse/APDFL-6053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ