### PR TITLE
Set with_dli option to False in Windows ARM profiles

### DIFF
--- a/profiles/msvc-arm64
+++ b/profiles/msvc-arm64
@@ -9,6 +9,7 @@ strawberryperl/*:arch=x86_64
 libiconv/*:arch=x86_64
 [options]
 opencv/*:neon=True
+adobe_pdf_library/*:with_dli=False
 [conf]
 tools.gnu:host_triplet=aarch64-w64-mingw32
 opencv/*:tools.build:cxxflags+=-D_ARM64_DISTINCT_NEON_TYPES=1


### PR DESCRIPTION
- When trying to update apdfl-cpp-utils to Conan 2, the apdfl-cpp-utils bootstrap was running into the following error on Windows ARM: 
`ConanException: Incorrect attempt to modify option 'with_dli' from 'True' to 'False'`

- The APDFL conanfile.py does set the "with_dli" option to False in the configure() method, but my guess is this gets evaluated later and apdfl_cpp_utils is seeing the default value of the "with_dli" option which is set to "True" in APDFL. Let's set the option to "False" in the Windows ARM profile to get it applied early in the dependency resolution.

**Relates to JIRA issue** [APDFL-6053](https://datalogics-jira.atlassian.net/browse/APDFL-6053)


[APDFL-6053]: https://datalogics-jira.atlassian.net/browse/APDFL-6053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ