### PR TITLE
Remove update value.

### DIFF
--- a/profiles/msvc-194
+++ b/profiles/msvc-194
@@ -1,4 +1,4 @@
 include(msvc-common)
 [settings]
 compiler.version=194
-compiler.update=2
+


### PR DESCRIPTION
Otherwise we're tied to MSVC v19.42 which has the linking problem we're experiencing, instead I'm just going to drop that version from the machines directly.