### PR TITLE
Set doxygen compiler.update to 2 on Windows 64

### DIFF
--- a/profiles/msvc-194
+++ b/profiles/msvc-194
@@ -2,3 +2,4 @@ include(msvc-common)
 [settings]
 compiler.version=194
 compiler.update=4
+doxygen/*:compiler.update=2


### PR DESCRIPTION
- The curated-conan-center-index nightly fails while trying to pre-build doxygen 1.9.4 with the following error in doxygen's "util.cpp" file: `error C2039: 'system_clock': is not a member of 'std::chrono'`

- The only thing that changed from the last successful build is that we updated the msvc compiler on the opportunity build machine to 14.44. It appears that the 14.44 compiler's msvc_chrono.hpp does not contain a definition for "system_clock". Also, the doxygen "util.cpp" doesn't seem to #include the "chrono" library. Let's just attempt to fallback to compiler.update=2 to get doxygen building again.