### PR TITLE
Add riscv64 arch to settings.yml

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -67,7 +67,7 @@ os:
     baremetal:
     VxWorks:
         version: ["7"]
-arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7, xtensalx6, xtensalx106, xtensalx7, ia64, ia64_32]
+arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7, xtensalx6, xtensalx106, xtensalx7, ia64, ia64_32, riscv64]
 compiler:
     sun-cc:
         version: ["5.10", "5.11", "5.12", "5.13", "5.14", "5.15"]


### PR DESCRIPTION
- After doing a "staging to production" merge in CCCI, the boost failed to build during Win32 bootstrap in multiple projects. It appears that the boost recipe was modified to add 'riscv64' arch for _b2_address_model property. To fix this, let's add the new arch to our settings.yml so it will get recognized.