### PR TITLE
Add a conf section to set the make program to GNU make.

### DIFF
--- a/profiles/gcc-10-aix-72
+++ b/profiles/gcc-10-aix-72
@@ -10,8 +10,11 @@ compiler.exception=None
 compiler.libcxx=libstdc++
 compiler.threads=posix
 compiler.exception=None
-
 build_type=Release
+
+[conf]
+tools.gnu:make_program=/opt/freeware/bin/gmake
+
 [options]
 # Fix up building b2 on AIX. This will skip toolset autodetection and make b2
 # use the CC and CXX variables for building itself (and maybe even for building


### PR DESCRIPTION
ICU is failing to build on AIX because it's finding the AIX version of make that isn't supported by ICU's build.
GNU Make should be used when available for consistency.  We had been doing this via PATH overrides in Conan 1, but this is a much cleaner solution.