### PR TITLE
Only set this config flag for the ICU package.

### DIFF
--- a/profiles/apple-clang-16.4
+++ b/profiles/apple-clang-16.4
@@ -13,4 +13,4 @@ build_type=Release
 
 [conf]
 # this is really for cross ICU builds that require GNU make
-tools.gnu:make_program=/usr/bin/gnumake
+icu/*:tools.gnu:make_program=/usr/bin/gnumake


### PR DESCRIPTION
This breaks other things that don't use GNU Make - but is necessary for ICU