### PR TITLE
Use x86_64 as the arch value when using xapian-core on Windows ARM

### DIFF
--- a/profiles/msvc-arm64
+++ b/profiles/msvc-arm64
@@ -7,6 +7,7 @@ msys2/*:arch=x86_64
 doxygen/*:arch=x86_64
 strawberryperl/*:arch=x86_64
 libiconv/*:arch=x86_64
+xapian-core/*:arch=x86_64
 [options]
 opencv/*:neon=True
 adobe_pdf_library/*:with_dli=False


### PR DESCRIPTION
This library does not build for windows arm. so we need to use the x86 binary