### PR TITLE
Refactored the boost-options and boost_excludes

### DIFF
--- a/profiles/boost-options
+++ b/profiles/boost-options
@@ -1,4 +1,9 @@
 [options]
 boost/*:i18n_backend_iconv=off
 boost/*:i18n_backend_icu=True
+boost/*:without_graph_parallel=True
+boost/*:without_mpi=True
 boost/*:without_process=True
+boost/*:without_python=True
+boost/*:without_stacktrace=True
+boost/*:without_wave=True

--- a/profiles/boost-options
+++ b/profiles/boost-options
@@ -8,3 +8,4 @@ boost/*:without_python=True
 boost/*:without_stacktrace=True
 boost/*:without_wave=True
 boost/*:without_graph=True
+boost/*:without_graph_parallel=True

--- a/profiles/boost-options
+++ b/profiles/boost-options
@@ -7,3 +7,4 @@ boost/*:without_process=True
 boost/*:without_python=True
 boost/*:without_stacktrace=True
 boost/*:without_wave=True
+boost/*:without_graph=True

--- a/profiles/boost_excludes
+++ b/profiles/boost_excludes
@@ -1,16 +1,11 @@
 [options]
-boost/*:without_fiber=True
-boost/*:without_mpi=True
-boost/*:without_python=True
-boost/*:without_wave=True
 boost/*:without_context=True
 boost/*:without_contract=True
 boost/*:without_coroutine=True
+boost/*:without_fiber=True
 boost/*:without_graph=True
-boost/*:without_graph_parallel=True
 boost/*:without_iostreams=True
 boost/*:without_json=True
-boost/*:without_process=True
 boost/*:without_serialization=True
 boost/*:without_timer=True
 boost/*:without_type_erasure=True


### PR DESCRIPTION
 Refactored the boost-options and boost_excludes profiles
- remove duplicates
- add without_stacktrace=True so that the few projects that use it can opt-in via the recipe (which they already do)