### PR TITLE
Allow boost serialization to be built on AIX.

### DIFF
--- a/profiles/boost_excludes
+++ b/profiles/boost_excludes
@@ -6,6 +6,5 @@ boost/*:without_fiber=True
 boost/*:without_graph=True
 boost/*:without_iostreams=True
 boost/*:without_json=True
-boost/*:without_serialization=True
 boost/*:without_timer=True
 boost/*:without_type_erasure=True


### PR DESCRIPTION
Don't exclude boost_serialization on AIX - it builds and causes a configuration validation error if it's off