### PR TITLE
APDFL-6681 - Use macOS-12.0 for apple-clang-16.4

### DIFF
--- a/profiles/apple-clang-16.4
+++ b/profiles/apple-clang-16.4
@@ -1,4 +1,4 @@
-include(macos-15.0)
+include(macos-12.0)
 include(options-libtiff)
 include(boost-options)
 

--- a/profiles/macos-15.0
+++ b/profiles/macos-15.0
@@ -1,5 +1,3 @@
 [settings]
 os=Macos
 os.version=15.0
-[buildenv]
-MACOSX_DEPLOYMENT_TARGET=12.0


### PR DESCRIPTION
1. Although our macOS build nodes are 15.x (Sequoia), setting `os.version` to 15.0 drives the _deployment_ target:

    From [Conan Documentation](https://docs.conan.io/2/reference/tools/apple/xcodebuild.html):

    `Deployment target setting according to the values of os and os.version from profile, e.g.
      MACOSX_DEPLOYMENT_TARGET=10.15 or IPHONEOS_DEPLOYMENT_TARGET=15.0`

2.  Remove `MACOSX_DEPLOYMENT_TARGET` from `macos-15.0` profile:

    Doesn't seem to have an effect on actual deployment.