### PR TITLE
Remove compiler.update from profiles

### DIFF
--- a/profiles/msvc-194
+++ b/profiles/msvc-194
@@ -1,4 +1,3 @@
 include(msvc-common)
 [settings]
 compiler.version=194
-compiler.update=4

--- a/profiles/msvc-arm64
+++ b/profiles/msvc-arm64
@@ -1,7 +1,5 @@
 [settings]
 arch=armv8
-# override the base compiler.update
-compiler.update=8
 # bring in settings from win-arm64-wsl
 msys2/*:arch=x86_64
 doxygen/*:arch=x86_64

--- a/profiles/msvc-common
+++ b/profiles/msvc-common
@@ -4,7 +4,6 @@ os=Windows
 os.subsystem=None
 compiler=msvc
 compiler.runtime=dynamic
-compiler.update=9
 compiler.toolset=v143
 build_type=Release
 [options]

--- a/settings.yml
+++ b/settings.yml
@@ -112,7 +112,7 @@ compiler:
         cppstd: [None, 14, 17, 20, 23]
     msvc:
         version: [170, 180, 190, 191, 192, 193, 194]
-        update: [None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        update: [null, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         runtime: [static, dynamic]
         runtime_type: [Debug, Release]
         cppstd: [98, 14, 17, 20, 23]


### PR DESCRIPTION
`msvc-arm64` has `compiler.update=8`

This forces us to use the MSVC 14.4**8** toolset compiler version (which doesn't exist) when using the [msvc-194](https://github.com/datalogics/conan-config/blob/develop/profiles/msvc-194) profile or the MSVC 14.3**8** toolset compiler version when using the [msvc-193](https://github.com/datalogics/conan-config/blob/develop/profiles/msvc-193) profile.

This explains why we were forced to install the 14.38 at some point on the `winARM` machines to get things to work.

More generally, remove `compiler.update` from _msvc_ profiles.

Also, update `None` to `null` for version values to match what conan 2 uses in settings for `msvc`

https://docs.conan.io/2/reference/config_files/settings.html