### PR TITLE
Add clang-cl Windows profiles for MSVC-ABI clang builds

### DIFF
--- a/profiles/clang-cl-20
+++ b/profiles/clang-cl-20
@@ -1,0 +1,3 @@
+include(clang-cl-common)
+[settings]
+compiler.version=20

--- a/profiles/clang-cl-20
+++ b/profiles/clang-cl-20
@@ -1,3 +1,6 @@
 include(clang-cl-common)
 [settings]
-compiler.version=20
+# The clang-cl bundled with Visual Studio 2022 is clang 19.1.x. The "20" in the
+# profile family name predates pinning the exact toolchain; the real compiler
+# version is 19.
+compiler.version=19

--- a/profiles/clang-cl-20-x64-cppstd-17
+++ b/profiles/clang-cl-20-x64-cppstd-17
@@ -1,0 +1,5 @@
+include(clang-cl-20)
+include(cppstd-17)
+
+[settings]
+arch=x86_64

--- a/profiles/clang-cl-20-x64-cppstd-20
+++ b/profiles/clang-cl-20-x64-cppstd-20
@@ -1,0 +1,5 @@
+include(clang-cl-20)
+include(cppstd-20)
+
+[settings]
+arch=x86_64

--- a/profiles/clang-cl-common
+++ b/profiles/clang-cl-common
@@ -6,6 +6,8 @@ os.subsystem=None
 compiler=clang
 compiler.runtime=dynamic
 compiler.runtime_type=Release
+compiler.libcxx="c++_shared"
+compiler.runtime_version=[v140-v145]
 build_type=Release
 [options]
 # --hash makes shorter filenames in the build directory, to avoid problems

--- a/profiles/clang-cl-common
+++ b/profiles/clang-cl-common
@@ -6,17 +6,36 @@ os.subsystem=None
 compiler=clang
 compiler.runtime=dynamic
 compiler.runtime_type=Release
-compiler.libcxx="c++_shared"
-compiler.runtime_version=[v140-v145]
+compiler.runtime_version=v144
+compiler.libcxx=c++_shared
 build_type=Release
 [options]
 # --hash makes shorter filenames in the build directory, to avoid problems
 # on Windows, where b2.exe is 32-bit and doesn't support long paths.
 boost/*:extra_b2_flags=--hash
 boost/*:pch=False
+[tool_requires]
+# clang-cl on Windows can only drive CMake via Ninja (the MinGW Makefiles
+# fallback needs a gcc/make toolchain). Provide ninja to every package built
+# with this profile so CMake-based dependencies (e.g. zlib) configure.
+ninja/[>=1.10.2 <2]
+[conf]
+# Force the Ninja generator and point CMake at clang-cl for dependency builds.
+tools.cmake.cmaketoolchain:generator=Ninja
+tools.build:compiler_executables={"c": "clang-cl", "cpp": "clang-cl"}
 [buildenv]
-# clang-cl is the MSVC-compatible Clang driver; mach and AutotoolsToolchain
-# pick it up from CC/CXX. The MSVC SDK/runtime must be on PATH (run inside a
-# Visual Studio developer environment / vcvars).
+# clang-cl is the MSVC-compatible Clang driver; mach and CMake pick it up from
+# CC/CXX. Visual Studio bundles clang-cl under VC/Tools/Llvm but does not put it
+# on PATH, so prepend it here. The MSVC SDK/runtime come from conanvcvars.
 CC=clang-cl
 CXX=clang-cl
+PATH=+(path)C:/Program Files/Microsoft Visual Studio/2022/Professional/VC/Tools/Llvm/x64/bin
+# Firefox 151's mach requires a full MozillaBuild tree on Windows (it adds
+# MozillaBuild's msys2 shell tools to PATH). The conan mozilla-build package
+# only ships nsinstall.exe, so point at a standalone MozillaBuild install.
+MOZILLABUILD=C:/mozilla-build
+# MozillaBuild ships no GNU make, and Mozilla's build rejects MSYS make
+# (baseconfig.mk: "MSYS make is not supported"). Append MSYS2's mingw64 bin,
+# which provides a *native* mingw32-make.exe that mach prefers over plain make;
+# MozillaBuild still supplies the msys2 shell. mingw64 has no link.exe to shadow.
+PATH+=(path)C:/msys64/mingw64/bin

--- a/profiles/clang-cl-common
+++ b/profiles/clang-cl-common
@@ -1,0 +1,20 @@
+include(global)
+include(win-boost-options)
+[settings]
+os=Windows
+os.subsystem=None
+compiler=clang
+compiler.runtime=dynamic
+compiler.runtime_type=Release
+build_type=Release
+[options]
+# --hash makes shorter filenames in the build directory, to avoid problems
+# on Windows, where b2.exe is 32-bit and doesn't support long paths.
+boost/*:extra_b2_flags=--hash
+boost/*:pch=False
+[buildenv]
+# clang-cl is the MSVC-compatible Clang driver; mach and AutotoolsToolchain
+# pick it up from CC/CXX. The MSVC SDK/runtime must be on PATH (run inside a
+# Visual Studio developer environment / vcvars).
+CC=clang-cl
+CXX=clang-cl

--- a/settings.yml
+++ b/settings.yml
@@ -126,6 +126,10 @@ compiler:
         toolset: [None, llvm-toolset-7]
         libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
+        # runtime/runtime_type let clang-cl on Windows select the MSVC runtime
+        # (clang-cl emits MSVC-ABI objects); null keeps them optional elsewhere.
+        runtime: [null, static, dynamic]
+        runtime_type: [null, Debug, Release]
         sanitizer: [null, address, thread, undefined, memory, hwaddress]
     apple-clang: &apple_clang
         version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1",

--- a/settings.yml
+++ b/settings.yml
@@ -123,7 +123,6 @@ compiler:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0", "7.1", "8", "9", "10", "11", "12",
                   "13", "14", "15", "16", "17", "18", "19", "20"]
-        toolset: [None, llvm-toolset-7]
         libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
         # runtime/runtime_type let clang-cl on Windows select the MSVC runtime

--- a/settings.yml
+++ b/settings.yml
@@ -125,10 +125,12 @@ compiler:
                   "13", "14", "15", "16", "17", "18", "19", "20"]
         libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
-        # runtime/runtime_type let clang-cl on Windows select the MSVC runtime
-        # (clang-cl emits MSVC-ABI objects); null keeps them optional elsewhere.
+        # runtime/runtime_type/runtime_version let clang-cl on Windows select
+        # the MSVC runtime (clang-cl emits MSVC-ABI objects); null keeps them
+        # optional elsewhere.
         runtime: [null, static, dynamic]
         runtime_type: [null, Debug, Release]
+        runtime_version: [null, v140, v141, v142, v143, v144]
         sanitizer: [null, address, thread, undefined, memory, hwaddress]
     apple-clang: &apple_clang
         version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1",


### PR DESCRIPTION
Attempting to create a Spider Monkey conan package.  This is possible, but requires quite a few dependencies, making it a bit impractical for automated builds on CI machines on Windows.
This profile is required to build SpiderMonkey, after installing MozillaBuild, MSYS2 and the MingWin32 GNU make programs, as well as the clang-cl toolkit for visual studio.  So these profiles will require all those prerequisites, and we should not build it very often.

## What

Adds a `clang-cl` profile chain for Windows so packages that require a
Clang toolchain (rather than pure MSVC) can be built while still targeting
the MSVC ABI/runtime:

- `profiles/clang-cl-common` → `clang-cl-20` → `clang-cl-20-x64-cppstd-{17,20}`
- Modeled as `compiler=clang` with the MSVC dynamic runtime, so `is_msvc()`
  is false but the binaries stay MSVC-ABI compatible.
- `settings.yml`: extends the `clang` compiler block with
  `runtime`/`runtime_type`/`runtime_version` (required for clang-on-Windows).
- The profile drives CMake via Ninja + `clang-cl`, provides `ninja` as a
  tool_require, and puts `clang-cl`, a native `mingw32-make`, and
  `MOZILLABUILD` on the build environment.

## Why

SpiderMonkey 151 (Firefox/`mach`) only builds on Windows with `clang-cl`,
not MSVC. These profiles enable that.

## Verification

`spidermonkey/151.0.4` builds, packages, and passes its `test_package`
end-to-end with `--profile:host clang-cl-20-x64-cppstd-20`
(SpiderMonkey 151 requires C++20; the cppstd-17 variant is included for
consistency but that package requires C++20).

## Caveats for reviewers

The build-env entries in `clang-cl-common` use machine-specific paths
(VS 2022 **Professional** LLVM dir, `C:/msys64/mingw64/bin`,
`C:/mozilla-build`). These assume a build host with VS clang-cl, a native
MSYS2 `mingw32-make`, and a real MozillaBuild install. Consider
parameterizing or documenting these as build-host prerequisites before
relying on this broadly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)