### PR TITLE
Drop compiler.toolset from clang profiles

### DIFF
--- a/profiles/android-armv8
+++ b/profiles/android-armv8
@@ -7,6 +7,5 @@ arch=armv8
 compiler=clang
 compiler.version="19"
 compiler.libcxx=c++_shared
-compiler.toolset=None
 build_type=Release
 

--- a/profiles/android-x86_64
+++ b/profiles/android-x86_64
@@ -7,5 +7,4 @@ arch=x86_64
 compiler=clang
 compiler.version="19"
 compiler.libcxx=c++_shared
-compiler.toolset=None
 build_type=Release

--- a/profiles/clang-18-linux
+++ b/profiles/clang-18-linux
@@ -4,7 +4,6 @@ os=Linux
 compiler=clang
 compiler.version=18
 compiler.libcxx=libstdc++
-compiler.toolset=None
 build_type=Release
 [buildenv]
 CC=/usr/bin/clang

--- a/profiles/clang-20-linux
+++ b/profiles/clang-20-linux
@@ -4,7 +4,6 @@ os=Linux
 compiler=clang
 compiler.version=20
 compiler.libcxx=libstdc++
-compiler.toolset=None
 build_type=Release
 [buildenv]
 CC=/usr/bin/clang


### PR DESCRIPTION
- Remove the dangling `compiler.toolset=None` line from `profiles/clang-20-linux`, `profiles/clang-18-linux`, `profiles/android-x86_64`, and `profiles/android-armv8`.

The clang `toolset` setting was removed from `settings.yml` when `llvm-toolset-7` was retired, but these clang-based profiles still set `compiler.toolset=None`, so every clang build now fails settings validation at bootstrap with `'settings.compiler.toolset' doesn't exist for 'clang'`. This blocks all Linux clang builds (webtopdf, pdfl18_installer, curator, cef). `msvc-common` keeps its `compiler.toolset` because `toolset` is still defined for msvc in `settings.yml`.