### PR TITLE
Prevent clang builds on the wrong machine

### DIFF
--- a/profiles/clang-18-linux
+++ b/profiles/clang-18-linux
@@ -6,5 +6,8 @@ compiler.version=18
 compiler.libcxx=libstdc++
 build_type=Release
 [buildenv]
-CC=/usr/bin/clang
-CXX=/usr/bin/clang++
+# Versioned paths so the compiler invoked always matches compiler.version
+CC=/usr/bin/clang-18
+CXX=/usr/bin/clang++-18
+[conf]
+tools.build:compiler_executables={"c": "/usr/bin/clang-18", "cpp": "/usr/bin/clang++-18"}

--- a/profiles/clang-20-linux
+++ b/profiles/clang-20-linux
@@ -6,5 +6,8 @@ compiler.version=20
 compiler.libcxx=libstdc++
 build_type=Release
 [buildenv]
-CC=/usr/bin/clang
-CXX=/usr/bin/clang++
+# Versioned paths so the compiler invoked always matches compiler.version
+CC=/usr/bin/clang-20
+CXX=/usr/bin/clang++-20
+[conf]
+tools.build:compiler_executables={"c": "/usr/bin/clang-20", "cpp": "/usr/bin/clang++-20"}


### PR DESCRIPTION
Prevent clang builds on the wrong machine from working by using the version-specific paths.

A problem was introduced by building on Rocky 9 with the 'clang-18-linux' profile for rocky 8 
- but it was actually picking up clang 20 on rocky 9, but marking the binaries as they would be for rocky 8.

This change prevents that from ever happening, because the paths won't be viable on the wrong system.